### PR TITLE
Add isEmpty util

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ General node js utils library.
 Currently supported utils:
 - `getArrayHasIntersect` - checks if arrays have at least one common value
 - `getArrayUniq` - gets unique values form array
+- `isEmpty` - Checks if value is an empty object, collection, map, or set
 - `isNil` - checks whenever value is null or undefined
 - `isPlainObject` - checks if input is object, not null object and not array object
 - `pick` - provides new object that picks only specific fields of source object

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 export function cloneDeep (obj: Object): Object
 export function getArrayHasIntersect (arr1: Array<any>, arr2: Array<any>): boolean
 export function getArrayUniq (arr: Array<any>): Array<any>
+export function isEmpty(val: any): boolean
 export function isNil(val: any): boolean
 export function isPlainObject(val: any): boolean
 export function pick(obj: Object, keys: Array<string>): Object

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const cloneDeep = require('./src/cloneDeep')
 const getArrayHasIntersect = require('./src/getArrayHasIntersect')
 const getArrayUniq = require('./src/getArrayUniq')
+const isEmpty = require('./src/isEmpty')
 const isNil = require('./src/isNil')
 const isPlainObject = require('./src/isPlainObject')
 const pick = require('./src/pick')
@@ -15,6 +16,7 @@ module.exports = {
   cloneDeep,
   getArrayHasIntersect,
   getArrayUniq,
+  isEmpty,
   isNil,
   isPlainObject,
   pick,

--- a/src/isEmpty.js
+++ b/src/isEmpty.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const isEmpty = (val) => {
+  if (!val) {
+    return true
+  }
+
+  if (
+    val instanceof Set ||
+    val instanceof Map
+  ) {
+    return !val.size
+  }
+  if (
+    Array.isArray(val) ||
+    typeof val === 'string' ||
+    (
+      typeof val?.[Symbol.iterator] === 'function' &&
+      Number.isFinite(val.length)
+    )
+  ) {
+    return !val.length
+  }
+
+  for (const key in val) {
+    if (
+      Object.prototype.hasOwnProperty.call(val, key) &&
+      key !== 'constructor'
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
+module.exports = isEmpty

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -1,0 +1,138 @@
+'use strict'
+
+/* eslint-env mocha */
+
+const assert = require('assert')
+const { isEmpty } = require('../index')
+
+const _toArgs = (array) => {
+  const wrapper = function () {
+    return arguments
+  }
+
+  return wrapper.apply(undefined, array)
+}
+
+describe('isEmpty', () => {
+  it('should return true for true boolean', () => {
+    assert.strictEqual(isEmpty(true), true)
+  })
+
+  it('should return true for false boolean', () => {
+    assert.strictEqual(isEmpty(false), true)
+  })
+
+  it('should return true for NaN', () => {
+    assert.strictEqual(isEmpty(NaN), true)
+  })
+
+  it('should return true for RegExp', () => {
+    assert.strictEqual(isEmpty(/x/), true)
+  })
+
+  it('should return true for Symbol', () => {
+    assert.strictEqual(isEmpty(Symbol('a')), true)
+  })
+
+  it('should return true for null', () => {
+    assert.strictEqual(isEmpty(null), true)
+  })
+
+  it('should return true for undefined', () => {
+    assert.strictEqual(isEmpty(undefined), true)
+  })
+
+  it('should return true for empty args', () => {
+    assert.strictEqual(isEmpty(), true)
+  })
+
+  it('should return true for 0 Buffer', () => {
+    assert.strictEqual(isEmpty(Buffer.alloc(0)), true)
+  })
+
+  it('should return false for 1 Buffer', () => {
+    assert.strictEqual(isEmpty(Buffer.alloc(1)), false)
+  })
+
+  it('should return true for empty string', () => {
+    assert.strictEqual(isEmpty(''), true)
+  })
+
+  it('should return false for string', () => {
+    assert.strictEqual(isEmpty('test'), false)
+  })
+
+  it('should return true for empty object', () => {
+    assert.strictEqual(isEmpty({}), true)
+  })
+
+  it('should return false for non-empty object', () => {
+    assert.strictEqual(isEmpty({ a: 0 }), false)
+  })
+
+  it('should return false for object that has `length=0` property', () => {
+    assert.strictEqual(isEmpty({ length: 0 }), false)
+  })
+
+  it('should return false for object that has `length="0"` property', () => {
+    assert.strictEqual(isEmpty({ length: '0' }), false)
+  })
+
+  it('should return true for negative lengths as array-like', () => {
+    function Foo () {}
+    Foo.prototype.length = -1
+
+    assert.strictEqual(isEmpty(new Foo()), true)
+  })
+
+  it('should return true for empty prototype objects', () => {
+    function Foo () {}
+    Foo.prototype = { constructor: Foo }
+
+    assert.strictEqual(isEmpty(Foo.prototype), true)
+  })
+
+  it('should return false for non-empty prototype objects', () => {
+    function Foo () {}
+    Foo.prototype = { constructor: Foo }
+    Foo.prototype.a = 1
+
+    assert.strictEqual(isEmpty(Foo.prototype), false)
+  })
+
+  it('should return true for Array.prototype.slice', () => {
+    assert.strictEqual(isEmpty(Array.prototype.slice), true)
+  })
+
+  it('should return true for empty array', () => {
+    assert.strictEqual(isEmpty([]), true)
+  })
+
+  it('should return false for non-empty array', () => {
+    assert.strictEqual(isEmpty([0]), false)
+  })
+
+  it('should return false for non-empty `arguments` objects', () => {
+    assert.strictEqual(isEmpty(_toArgs([1, 2, 3])), false)
+  })
+
+  it('should return true for empty `arguments` objects', () => {
+    assert.strictEqual(isEmpty(_toArgs([])), true)
+  })
+
+  it('should return false for non-empty Map', () => {
+    assert.strictEqual(isEmpty(new Map([['a', 1]])), false)
+  })
+
+  it('should return true for empty Map', () => {
+    assert.strictEqual(isEmpty(new Map()), true)
+  })
+
+  it('should return false for non-empty Set', () => {
+    assert.strictEqual(isEmpty(new Set([1])), false)
+  })
+
+  it('should return true for empty Set', () => {
+    assert.strictEqual(isEmpty(new Set()), true)
+  })
+})

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -85,6 +85,20 @@ describe('isEmpty', () => {
     assert.strictEqual(isEmpty(new Foo()), true)
   })
 
+  it('should return true for empty Class', () => {
+    class Foo {}
+
+    assert.strictEqual(isEmpty(new Foo()), true)
+  })
+
+  it('should return false for non-empty Class', () => {
+    class Foo {
+      a = 1
+    }
+
+    assert.strictEqual(isEmpty(new Foo()), false)
+  })
+
   it('should return true for empty prototype objects', () => {
     function Foo () {}
     Foo.prototype = { constructor: Foo }


### PR DESCRIPTION
This PR adds `isEmpty` util, it checks if value is an empty object, collection, map, or set

---

Note:
- the version is not increased, we have some PRs, that can be collected into one
