### PR TITLE
Fix merge to not throw err with non obj in src

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.2.1
+- fix: merge should not throw an error with non-plain objects in sources
+
 # 1.2.0
 - feat: get
 - feat: isEmpty

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinex/lib-js-util-base",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "general utils",
   "main": "index.js",
   "scripts": {

--- a/src/merge.js
+++ b/src/merge.js
@@ -29,6 +29,10 @@ const merge = (target, ...sources) => {
   const cloneObj = _cloneObj(target)
 
   for (const source of sources) {
+    if (!isPlainObject(source)) {
+      continue
+    }
+
     const keys = Object.keys(source)
 
     for (const key of keys) {

--- a/test/merge.js
+++ b/test/merge.js
@@ -129,4 +129,11 @@ describe('merge', () => {
     circularObj.self = circularObj
     assert.deepStrictEqual(merge({}, circularObj), Object.assign({}, circularObj))
   })
+
+  it('should not throw an error with non-plain objects in sources', () => {
+    const expected = { a: 4 }
+    const actual = merge({ a: 1 }, expected, undefined, null, true, '', NaN, /x/, Symbol('a'))
+
+    assert.deepStrictEqual(actual, expected)
+  })
 })


### PR DESCRIPTION
### Description:

This PR fixes `merge` util to not throw an error with non-plain objects in sources

### Fixes:
- [x] merge should not throw an error with non-plain objects in sources

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Tests added or updated
- [x] PR keeps 100% test coverage
- [ ] Type definition updated
- [x] Readme updated
- [x] Linter is applied
- [x] Const arrow functions are used instead of pure function definitions where applicable
- [x] Functions are listed in alphabetic order in index.js, index.d.ts and readme
