### PR TITLE
Fix clone deep to not throw err for non obj

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.5.1
+- fix: cloneDeep should not throw an error when cloning non-objects
+
 # 1.5.0
 - feat: shuffle
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinex/lib-js-util-base",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "general utils",
   "main": "index.js",
   "scripts": {

--- a/src/cloneDeep.js
+++ b/src/cloneDeep.js
@@ -3,6 +3,9 @@
 const isObject = require('./isObject')
 
 const cloneDeep = (obj) => {
+  if (obj instanceof Function) {
+    return {}
+  }
   if (!isObject(obj)) {
     return obj
   }

--- a/src/cloneDeep.js
+++ b/src/cloneDeep.js
@@ -1,5 +1,13 @@
 'use strict'
 
-const cloneDeep = (obj) => JSON.parse(JSON.stringify(obj))
+const isObject = require('./isObject')
+
+const cloneDeep = (obj) => {
+  if (!isObject(obj)) {
+    return obj
+  }
+
+  return JSON.parse(JSON.stringify(obj))
+}
 
 module.exports = cloneDeep

--- a/test/cloneDeep.js
+++ b/test/cloneDeep.js
@@ -3,7 +3,7 @@
 /* eslint-env mocha */
 
 const assert = require('assert')
-const { cloneDeep } = require('../index')
+const { cloneDeep, isPlainObject } = require('../index')
 
 describe('cloneDeep', () => {
   it('should deep clone objects', () => {
@@ -25,6 +25,13 @@ describe('cloneDeep', () => {
 
     for (const obj of sources) {
       const clone = cloneDeep(obj)
+
+      if (obj instanceof Function) {
+        assert.strictEqual(isPlainObject(clone), true)
+
+        return
+      }
+
       assert.deepStrictEqual(obj, clone)
     }
   })

--- a/test/cloneDeep.js
+++ b/test/cloneDeep.js
@@ -19,4 +19,13 @@ describe('cloneDeep', () => {
     assert.deepStrictEqual(obj, clone)
     assert.notStrictEqual(obj, clone)
   })
+
+  it('should not throw an error when cloning non-objects', () => {
+    const sources = [undefined, Symbol('a'), () => {}]
+
+    for (const obj of sources) {
+      const clone = cloneDeep(obj)
+      assert.deepStrictEqual(obj, clone)
+    }
+  })
 })


### PR DESCRIPTION
### Description:

This PR fixes `cloneDeep` util to not throw an error when cloning non-objects

### Fixes:
- [x] `cloneDeep` should not throw an error when cloning non-objects:
  - If pass `undefined` to `JSON.parse()` an `SyntaxError` will be thrown: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#exceptions
  - `JSON.stringify()` can return `undefined` when passing in "pure" values like `JSON.stringify(undefined)`, `JSON.stringify(Symbol('a'))`, `JSON.stringify(() => {})`
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Tests added or updated
- [x] PR keeps 100% test coverage
- [ ] Type definition updated
- [x] Readme updated
- [x] Linter is applied
- [x] Const arrow functions are used instead of pure function definitions where applicable
- [x] Functions are listed in alphabetic order in index.js, index.d.ts and readme
