### PR TITLE
feat: add resolvePromiseCb

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Currently supported utils:
 - `omitBy` -  provides new object that omits only specific fields of source object depending on predicate function filter
 - `pick` - provides new object that picks only specific fields of source object
 - `pickBy` -  provides new object that picks only specific fields of source object depending on predicate function filter
+- `resolvePromiseCb` -  helper to add callback support to async functions
 - `shuffle` - performs pseudo random shuffle on clone of the array
 - `sum` - calculate sum of array items
 - `sumBy` - calculate sum of array items using iteratee function or string shortcut

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,9 @@ export function omit (obj: Object, keys: Array<string>): Object
 export function omitBy (obj: Object, predicate: (val: any, key: string) => boolean): Object
 export function pick (obj: Object, keys: Array<string>): Object
 export function pickBy (obj: Object, predicate: (val: any, key: string) => boolean): Object
+export function resolvePromiseCb<T> (err: any, res: T, cb: (err: any, res: T) => void): Promise<T>|void
 export function shuffle<T> (array: Array<T>): Array<T>
+export function snakeCase (str: string): string
 export function sum (values: Array<string>): number
 export function sumBy (values: Array, iteratee: Function | string): number
 export function uniqBy (array: Array, iteratee: Function | string): Array

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const omit = require('./src/omit')
 const omitBy = require('./src/omitBy')
 const pick = require('./src/pick')
 const pickBy = require('./src/pickBy')
+const resolvePromiseCb = require('./src/resolvePromiseCb')
 const shuffle = require('./src/shuffle')
 const sum = require('./src/sum')
 const sumBy = require('./src/sumBy')
@@ -67,6 +68,7 @@ module.exports = {
   omitBy,
   pick,
   pickBy,
+  resolvePromiseCb,
   shuffle,
   sum,
   sumBy,

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const pick = require('./src/pick')
 const pickBy = require('./src/pickBy')
 const resolvePromiseCb = require('./src/resolvePromiseCb')
 const shuffle = require('./src/shuffle')
+const snakeCase = require('./src/snakeCase')
 const sum = require('./src/sum')
 const sumBy = require('./src/sumBy')
 const uniqBy = require('./src/uniqBy')
@@ -70,6 +71,7 @@ module.exports = {
   pickBy,
   resolvePromiseCb,
   shuffle,
+  snakeCase,
   sum,
   sumBy,
   uniqBy,

--- a/src/resolvePromiseCb.js
+++ b/src/resolvePromiseCb.js
@@ -1,0 +1,17 @@
+'use strict'
+
+/**
+ *
+ * @param {*} err
+ * @param {*} res
+ * @param {Function} cb
+ * @returns
+ */
+const resolvePromiseCb = (err, res, cb) => {
+  const isCb = typeof cb === 'function'
+  if (!err) return isCb ? cb(null, res) : Promise.resolve(res)
+  if (isCb) return cb(err)
+  return Promise.reject(err)
+}
+
+module.exports = resolvePromiseCb

--- a/src/snakeCase.js
+++ b/src/snakeCase.js
@@ -1,0 +1,19 @@
+'use strict'
+
+/**
+ * Converts camel case and strings separated by spaces and dashes to underscores
+ * @param {string} str
+ * @returns {string}
+ */
+const snakeCase = (str) => {
+  // Convert camelCase to snake_case by adding an underscore before each uppercase letter
+  // and converting it to lowercase
+  str = str.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+
+  // Convert spaces and dashes to underscores
+  str = str.replace(/[\s-]+/g, '_')
+
+  return str.toLowerCase()
+}
+
+module.exports = snakeCase

--- a/test/resolvePromiseCb.js
+++ b/test/resolvePromiseCb.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/* eslint-env mocha */
+
+const assert = require('assert')
+const resolvePromiseCb = require('../src/resolvePromiseCb')
+
+describe.only('resolvePromiseCb', () => {
+  it('should handle callback errors', (done) => {
+    resolvePromiseCb(new Error('foo'), null, (err) => {
+      assert.strictEqual(err.message, 'foo')
+      done()
+    })
+  })
+
+  it('should handle promise rejections', async () => {
+    await assert.rejects(resolvePromiseCb(new Error('foo')), { message: 'foo' })
+  })
+
+  it('should handle callback results', (done) => {
+    resolvePromiseCb(null, 'foo', (err, res) => {
+      assert.strictEqual(err, null)
+      assert.strictEqual(res, 'foo')
+      done()
+    })
+  })
+
+  it('should handle promise resolves', async () => {
+    const res = await resolvePromiseCb(null, 'foo')
+    assert.strictEqual(res, 'foo')
+  })
+})

--- a/test/resolvePromiseCb.js
+++ b/test/resolvePromiseCb.js
@@ -5,7 +5,7 @@
 const assert = require('assert')
 const resolvePromiseCb = require('../src/resolvePromiseCb')
 
-describe.only('resolvePromiseCb', () => {
+describe('resolvePromiseCb', () => {
   it('should handle callback errors', (done) => {
     resolvePromiseCb(new Error('foo'), null, (err) => {
       assert.strictEqual(err.message, 'foo')

--- a/test/snakeCase.js
+++ b/test/snakeCase.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/* eslint-env mocha */
+
+const assert = require('assert')
+const { snakeCase } = require('../index')
+
+describe('snakeCase', () => {
+  it('should work with empty string', () => {
+    assert.equal(snakeCase(''), '')
+  })
+
+  it('should convert string from camel case to snake case', () => {
+    assert.equal(snakeCase('camelCaseString'), 'camel_case_string')
+  })
+
+  it('should convert string separated with spaces to snake case', () => {
+    assert.equal(snakeCase('camel Case STRING'), 'camel_case_string')
+  })
+
+  it('should do nothing when is already in snake case', () => {
+    assert.equal(snakeCase('camel_case_string'), 'camel_case_string')
+  })
+})


### PR DESCRIPTION
### Description:
Add `resolvePromiseCb` helper

### Breaking changes:
None

### New features:
- [ ] Add `resolvePromiseCb` helper

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [x] Tests added or updated
- [x] PR keeps 100% test coverage
- [x] Type definition updated
- [x] Readme updated
- [x] Linter is applied
- [x] Const arrow functions are used instead of pure function definitions where applicable
- [x] Functions are listed in alphabetic order in index.js, index.d.ts and readme
