### PR TITLE
Feat/unset object path

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-#1.19.1
+#1.19.0
 - feat: add unset
 #1.18.1
 - feat: Add URL validation

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+#1.19.1
+- feat: add unset
 #1.18.1
 - feat: Add URL validation
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ const uniqWith = require('./src/uniqWith')
 const update = require('./src/update')
 const validateInput = require('./src/validateInput')
 const without = require('./src/without')
+const unset = require('./src/unset')
+
 
 module.exports = {
   assignInWith,
@@ -97,5 +99,6 @@ module.exports = {
   uniqWith,
   update,
   validateInput,
-  without
+  without,
+  unset
 }

--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ const validateInput = require('./src/validateInput')
 const without = require('./src/without')
 const unset = require('./src/unset')
 
-
 module.exports = {
   assignInWith,
   camelize,

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
   "devDependencies": {
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
-    "standard": "^17.1.0"
-  },
-  "dependencies": {
+    "standard": "^17.1.0",
     "mocha-it-each": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "standard": "^17.1.0"
+  },
+  "dependencies": {
+    "mocha-it-each": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinexcom/lib-js-util-base",
-  "version": "1.18.1",
+  "version": "1.19.1",
   "description": "general utils",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinexcom/lib-js-util-base",
-  "version": "1.19.1",
+  "version": "1.19.0",
   "description": "general utils",
   "main": "index.js",
   "scripts": {

--- a/src/unset.js
+++ b/src/unset.js
@@ -10,9 +10,14 @@ const _doUnset = (obj, path) => {
   const key = path.shift()
   if (obj[key] !== undefined) {
     if (level > 0) _doUnset(obj[key], path)
-    if (level === 0 || (isPlainObject(obj[key]) && isEmpty(obj[key]))) {
+    if (level === 0 || ((isPlainObject(obj[key]) || Array.isArray(obj[key])) && isEmpty(obj[key]))) {
       try {
-        return !Object.isFrozen(obj) && delete obj[key]
+        if (Object.isFrozen(obj)) return false
+        if (Array.isArray(obj)) {
+          return obj.length === 0 || obj.splice(+key, 1).length > 0
+        } else {
+          return delete obj[key]
+        }
       } catch (err) {
         return false
       }

--- a/src/unset.js
+++ b/src/unset.js
@@ -3,6 +3,7 @@
 const pathToArray = require('./util/pathToArray')
 const isEmpty = require('./isEmpty')
 const isPlainObject = require('./isPlainObject')
+const get = require('./get')
 
 const _doUnset = (obj, path) => {
   const level = path.length - 1
@@ -24,10 +25,11 @@ const _doUnset = (obj, path) => {
  *
  * @param {any} object
  * @param {string | Array} path
- * @returns {boolean} true if the path was found and deleted, false otherwise
+ * @returns {boolean} true if the path was found and deleted or did not exist, false otherwise
  */
 const unset = (object, path) => {
-  return _doUnset(object, pathToArray(path))
+  _doUnset(object, pathToArray(path))
+  return get(object, path, undefined) === undefined
 }
 
 module.exports = unset

--- a/src/unset.js
+++ b/src/unset.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const pathToArray = require('./util/pathToArray')
+const isEmpty = require('./isEmpty')
+const isPlainObject = require('./isPlainObject')
+
+const _doUnset = (obj, path) => {
+  const level = path.length - 1
+  const key = path.shift()
+  if (obj[key] !== undefined) {
+    if (level > 0) _doUnset(obj[key], path)
+    if (level === 0 || (isPlainObject(obj[key]) && isEmpty(obj[key]))) {
+      try {
+        return !Object.isFrozen(obj) && delete obj[key]
+      } catch (err) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+/**
+ *
+ * @param {any} object
+ * @param {string | Array} path
+ * @returns {boolean} true if the path was found and deleted, false otherwise
+ */
+const unset = (object, path) => {
+  return _doUnset(object, pathToArray(path))
+}
+
+module.exports = unset

--- a/src/unset.js
+++ b/src/unset.js
@@ -23,8 +23,8 @@ const _doUnset = (obj, path) => {
 
 /**
  * Given a path to a property into an object, follow and unset the matching field at
- * any arbitrary depth removing any remnant empty object encountered. Returns true if 
- * the path was successfully unset or it didn't exist. False if the path was found but could not 
+ * any arbitrary depth removing any remnant empty object encountered. Returns true if
+ * the path was successfully unset or it didn't exist. False if the path was found but could not
  * be unset (such as frozen objects or native properties)
  * @param {any} object
  * @param {string | Array} path

--- a/src/unset.js
+++ b/src/unset.js
@@ -22,7 +22,10 @@ const _doUnset = (obj, path) => {
 }
 
 /**
- *
+ * Given a path to a property into an object, follow and unset the matching field at
+ * any arbitrary depth removing any remnant empty object encountered. Returns true if 
+ * the path was successfully unset or it didn't exist. False if the path was found but could not 
+ * be unset (such as frozen objects or native properties)
  * @param {any} object
  * @param {string | Array} path
  * @returns {boolean} true if the path was found and deleted or did not exist, false otherwise

--- a/src/validateInput.js
+++ b/src/validateInput.js
@@ -21,7 +21,7 @@ const IMAGE = /^data:image\/[A-Za-z+]+;base64,[A-Za-z0-9+/=]+$/
 const FILE = /^data:(image|application|video)\/[A-Za-z0-9+]+;base64,[A-Za-z0-9+/=]+$/
 const FILENAME = new RegExp(`^[-${DIGITS}.${CHARACTERS} ()_]+$`, 'u')
 const PASSWORD = /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
-const URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/
+const URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/
 
 /**
  * @param {string} input

--- a/test/unset.js
+++ b/test/unset.js
@@ -10,13 +10,17 @@ describe('unset', () => {
   itEach('should be able to unset an object an any arbitrary depth returning true on success',
     [
       [{ a: 'foo' }, 'a', {}],
-      [{ b:  null }, 'b', {}],
-      [{ d:  0 }, 'd', {}],
+      [{ a: ['foo', 'bar'] }, 'a[1]', { a: ['foo'] }],
+      [{ a: 'foo', b: [{ a: 'bar', c: 'baz' }] }, 'b[0].a', { a: 'foo', b: [{ c: 'baz' }] }],
+      [{ b: null }, 'b', {}],
+      [{ d: 0 }, 'd', {}],
       [{ a: 'bar', b: { a: 'foo' } }, 'b.a', { a: 'bar' }],
       [{ a: 'bar', b: { a: 'foo', c: 'baz' } }, 'b.a', { a: 'bar', b: { c: 'baz' } }],
       [{ a: 'baz', b: { a: { c: 'baz' } } }, 'b.a.c', { a: 'baz' }],
+      [{ a: 'baz', b: { a: { c: [{ k: 'baz' }] } } }, 'b.a.c[0].k', { a: 'baz' }],
       [{ a: 'baz', b: { a: { c: 'baz', d: 'koo' } } }, 'b.a.c', { a: 'baz', b: { a: { d: 'koo' } } }],
       [{ a: 'baz', b: { a: { c: 'baz', d: 'koo' } } }, 'b.a.d', { a: 'baz', b: { a: { c: 'baz' } } }],
+      [{ a: 'baz', b: { a: { c: 'baz', d: [{ foo: 'koo', bar: 'fooz' }] } } }, 'b.a.d[0].bar', { a: 'baz', b: { a: { c: 'baz', d: [{ foo: 'koo' }] } } }],
       [{ a: 'baz', b: { a: { c: 'baz', d: 'koo' } } }, 'a', { b: { a: { c: 'baz', d: 'koo' } } }]
     ],
     async ([obj, path, expected]) => {

--- a/test/unset.js
+++ b/test/unset.js
@@ -10,6 +10,8 @@ describe('unset', () => {
   itEach('should be able to unset an object an any arbitrary depth returning true on success',
     [
       [{ a: 'foo' }, 'a', {}],
+      [{ b:  null }, 'b', {}],
+      [{ d:  0 }, 'd', {}],
       [{ a: 'bar', b: { a: 'foo' } }, 'b.a', { a: 'bar' }],
       [{ a: 'bar', b: { a: 'foo', c: 'baz' } }, 'b.a', { a: 'bar', b: { c: 'baz' } }],
       [{ a: 'baz', b: { a: { c: 'baz' } } }, 'b.a.c', { a: 'baz' }],

--- a/test/unset.js
+++ b/test/unset.js
@@ -7,7 +7,7 @@ const unset = require('../src/unset')
 const { itEach } = require('mocha-it-each')
 
 describe('unset', () => {
-  itEach('should be able to unset an object an any arbitrary depth',
+  itEach('should be able to unset an object an any arbitrary depth returning true on success',
     [
       [{ a: 'foo' }, 'a', {}],
       [{ a: 'bar', b: { a: 'foo' } }, 'b.a', { a: 'bar' }],

--- a/test/unset.js
+++ b/test/unset.js
@@ -6,7 +6,7 @@ const assert = require('assert')
 const unset = require('../src/unset')
 const { itEach } = require('mocha-it-each')
 
-describe.only('unset', () => {
+describe('unset', () => {
   itEach('should be able to unset an object an any arbitrary depth',
     [
       [{ a: 'foo' }, 'a', {}],
@@ -20,7 +20,7 @@ describe.only('unset', () => {
     async ([obj, path, expected]) => {
       const found = unset(obj, path)
       assert.deepStrictEqual(obj, expected)
-      console.debug(found)
+      assert.strictEqual(found, true)
     })
 
   itEach('should return true even when target was not found ',
@@ -39,7 +39,7 @@ describe.only('unset', () => {
 
   itEach('should return false when target was found but could not be removed',
     [
-      // [Object.freeze({ a: 'foo' }), 'a'],
+      [Object.freeze({ a: 'foo' }), 'a'],
       [{ a: 'bar', b: Object.freeze({ a: 'foo' }) }, 'b.a'],
       [{ a: 'bar', b: Object.freeze({ a: 'foo', c: 'baz' }) }, 'b.c'],
       [{ a: 'baz', b: { a: Object.freeze({ c: 'baz' }) } }, 'b.a.c'],

--- a/test/unset.js
+++ b/test/unset.js
@@ -1,0 +1,51 @@
+'use strict'
+
+/* eslint-env mocha */
+
+const assert = require('assert')
+const unset = require('../src/unset')
+const { itEach } = require('mocha-it-each')
+
+describe.only('unset', () => {
+  itEach('should be able to unset an object an any arbitrary depth',
+    [
+      [{ a: 'foo' }, 'a', {}],
+      [{ a: 'bar', b: { a: 'foo' } }, 'b.a', { a: 'bar' }],
+      [{ a: 'bar', b: { a: 'foo', c: 'baz' } }, 'b.a', { a: 'bar', b: { c: 'baz' } }],
+      [{ a: 'baz', b: { a: { c: 'baz' } } }, 'b.a.c', { a: 'baz' }],
+      [{ a: 'baz', b: { a: { c: 'baz', d: 'koo' } } }, 'b.a.c', { a: 'baz', b: { a: { d: 'koo' } } }],
+      [{ a: 'baz', b: { a: { c: 'baz', d: 'koo' } } }, 'b.a.d', { a: 'baz', b: { a: { c: 'baz' } } }],
+      [{ a: 'baz', b: { a: { c: 'baz', d: 'koo' } } }, 'a', { b: { a: { c: 'baz', d: 'koo' } } }]
+    ],
+    async ([obj, path, expected]) => {
+      const found = unset(obj, path)
+      assert.deepStrictEqual(obj, expected)
+      console.debug(found)
+    })
+
+  itEach('should return true even when target was not found ',
+    [
+      [{}, 'b'],
+      [{}, 'b.f'],
+      [{ a: 'foo' }, 'b'],
+      [{ a: 'bar', b: { a: 'foo' } }, 'b.c'],
+      [{ a: 'bar', b: { a: 'foo', c: 'baz' } }, 'b.d'],
+      [{ a: 'baz', b: { a: { c: 'baz' } } }, 'b.a.k'],
+      [{ a: 'baz', b: { a: { c: 'baz', d: 'koo' } } }, 'b.f.d']
+    ],
+    async ([obj, path]) => {
+      assert.strictEqual(unset(obj, path), true)
+    })
+
+  itEach('should return false when target was found but could not be removed',
+    [
+      // [Object.freeze({ a: 'foo' }), 'a'],
+      [{ a: 'bar', b: Object.freeze({ a: 'foo' }) }, 'b.a'],
+      [{ a: 'bar', b: Object.freeze({ a: 'foo', c: 'baz' }) }, 'b.c'],
+      [{ a: 'baz', b: { a: Object.freeze({ c: 'baz' }) } }, 'b.a.c'],
+      [Object.freeze({ a: 'baz', b: { a: { c: 'baz', d: 'koo' } } }), 'a']
+    ],
+    async ([obj, path]) => {
+      assert.strictEqual(unset(obj, path), false)
+    })
+})


### PR DESCRIPTION
### Description:
Add new unset method

Given a path to a property into an object or an array, follow and unset the matching field at any arbitrary depth removing any remanant empty object or arrays encountered. Returns true if the path was successfully unset or it didn't exisit. False if the path was found but could not be unset (such as frozen objects or native properties)

```
 eg. 1. unset({a: 'bar'} , 'a') => {}
     2. unset({a: b:{c:'fooz'}}, 'a.b.c') => {}
     3. unset({a: 'fooz', b: {d: 'bar'}}, 'b') => {a:'fooz'}
     4. unset({a: 'fooz', b: {d:{k: 'bar'}}}, 'b.d') => {a:'fooz'}
     5. unset({a: ['foo', 'bar']}, 'a[1]') => {a:['foo']}
     6. unset({a: [{foo: 'bar', bar: 'fooz'}], 'a[0].bar') => {a: [{foo: 'bar'}]}
```

### Breaking changes:
- [ ]

### New features:
- [ ] unset a path according to a period delimited property names('a.b.c') or an array of properties (['a', 'b', 'c'])

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] PR keeps 100% test coverage
- [ ] Type definition updated
- [ ] Readme updated
- [ ] Linter is applied
- [ ] Const arrow functions are used instead of pure function definitions where applicable
- [ ] Functions are listed in alphabetic order in index.js, index.d.ts and readme
