### PR TITLE
Fix cloneDeep to consider Buffer is not available in browser engine

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+#2.0.1
+- fix: fix cloneDeep to consider that Buffer is not available in the browser engine
+
 #1.22.0
 - feat: add chunk - splits array into chunks of specified size
 - feat: add isBoolean - checks if value is a boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitfinex/lib-js-util-base",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitfinex/lib-js-util-base",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "mocha": "10.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinex/lib-js-util-base",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "general utils",
   "main": "index.js",
   "scripts": {

--- a/src/cloneDeep.js
+++ b/src/cloneDeep.js
@@ -27,7 +27,9 @@ const cloneDeep = (obj, clones = new WeakMap()) => {
     })
     return newSet
   }
-  if (Buffer.isBuffer(obj)) return Buffer.from(obj)
+  if (typeof Buffer === 'function' && Buffer.isBuffer(obj)) {
+    return Buffer.from(obj)
+  }
   if (ArrayBuffer.isView(obj) && !(obj instanceof DataView)) {
     return new obj.constructor(obj)
   }


### PR DESCRIPTION
### Description:
This fixes `cloneDeep` to consider that Buffer is not available in the browser engine
Related to these issues:
- https://github.com/bitfinexcom/lib-js-util-base/issues/48
- https://github.com/bitfinexcom/bfx-report-ui/pull/1025#pullrequestreview-3854629303

### Fixes:
- [x] `cloneDeep` should not throw an error in the browser engine as Buffer is not available there:

### PR status:
- [x] Version bumped in package.json and package-lock.json
- [x] Change-log updated
- [ ] Tests added or updated
- [x] PR keeps 100% test coverage
- [ ] Type definition updated
- [ ] Readme updated
- [x] Linter is applied
- [x] Const arrow functions are used instead of pure function definitions where applicable
- [x] Functions are listed in alphabetic order in index.js, index.d.ts and readme
- [ ] NPM audit reports no issues
