### PR TITLE
Fix unset and omit to handle that if prop value of obj is undefined but exists

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+#2.0.2
+- fix: fix unset and omit to handle that if prop value of obj is undefined but exists
+
 #2.0.1
 - fix: fix cloneDeep to consider that Buffer is not available in the browser engine
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitfinex/lib-js-util-base",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitfinex/lib-js-util-base",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
         "mocha": "10.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinex/lib-js-util-base",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "general utils",
   "main": "index.js",
   "scripts": {

--- a/src/unset.js
+++ b/src/unset.js
@@ -8,7 +8,7 @@ const get = require('./get')
 const _doUnset = (obj, path) => {
   const level = path.length - 1
   const key = path.shift()
-  if (obj[key] !== undefined) {
+  if (Object.hasOwn(obj, key)) {
     if (level > 0) _doUnset(obj[key], path)
     if (level === 0 || ((isPlainObject(obj[key]) || Array.isArray(obj[key])) && isEmpty(obj[key]))) {
       try {

--- a/test/omit.js
+++ b/test/omit.js
@@ -55,4 +55,10 @@ describe('omit', () => {
     const result = omit(input, undefined)
     assert.deepStrictEqual(result, { a: 1, b: 2, c: 3 })
   })
+
+  it('should handle if value is undefined but exists', () => {
+    const input = { a: undefined, b: 2, c: 3 }
+    const result = omit(input, ['a'])
+    assert.deepStrictEqual(result, { b: 2, c: 3 })
+  })
 })

--- a/test/unset.js
+++ b/test/unset.js
@@ -13,6 +13,7 @@ describe('unset', () => {
       [{ a: ['foo', 'bar'] }, 'a[1]', { a: ['foo'] }],
       [{ a: 'foo', b: [{ a: 'bar', c: 'baz' }] }, 'b[0].a', { a: 'foo', b: [{ c: 'baz' }] }],
       [{ b: null }, 'b', {}],
+      [{ b: undefined }, 'b', {}],
       [{ d: 0 }, 'd', {}],
       [{ a: 'bar', b: { a: 'foo' } }, 'b.a', { a: 'bar' }],
       [{ a: 'bar', b: { a: 'foo', c: 'baz' } }, 'b.a', { a: 'bar', b: { c: 'baz' } }],


### PR DESCRIPTION
### Description:

This PR fixes `unset` and `omit` to handle that if prop value of obj is undefined but exists

### Fixes:
- [x] `unset` and `omit` should handle if prop value of obj is undefined but exists

### PR status:
- [x] Version bumped in package.json and package-lock.json
- [x] Change-log updated
- [x] Tests added or updated
- [x] PR keeps 100% test coverage
- [ ] Type definition updated
- [ ] Readme updated
- [x] Linter is applied
- [x] Const arrow functions are used instead of pure function definitions where applicable
- [x] Functions are listed in alphabetic order in index.js, index.d.ts and readme
- [ ] NPM audit reports no issues
